### PR TITLE
Add missing Total title in Orderbook

### DIFF
--- a/src/feature/perp/layouts/orderbook/index.tsx
+++ b/src/feature/perp/layouts/orderbook/index.tsx
@@ -2,6 +2,7 @@ import { useGeneralContext } from "@/context";
 import { Popover, PopoverContent, PopoverTrigger } from "@/lib/shadcn/popover";
 import { FuturesAssetProps, TradeExtension } from "@/models";
 import { cn } from "@/utils/cn";
+import { formatSymbol } from "@/utils/misc";
 import { getFormattedAmount, getStyleFromDevice } from "@/utils/misc";
 import {
   useMarketTradeStream,
@@ -10,7 +11,7 @@ import {
 import { useRef, useState } from "react";
 import { IoChevronDown } from "react-icons/io5";
 import { TradeSection } from "./trade-section";
-
+1
 enum OrderbookSection {
   ORDERBOOK,
   TRADE_HISTORY,
@@ -42,12 +43,12 @@ export const Orderbook = ({
         isMobileOpenTrade || isMobile
           ? 8
           : (sectionRef?.current?.clientHeight as number) > 950
-          ? 18
-          : (sectionRef?.current?.clientHeight as number) > 900
-          ? 16
-          : (sectionRef?.current?.clientHeight as number) > 800
-          ? 14
-          : 12,
+            ? 18
+            : (sectionRef?.current?.clientHeight as number) > 900
+              ? 16
+              : (sectionRef?.current?.clientHeight as number) > 800
+                ? 14
+                : 12,
       padding: false,
     });
   const bestBid: number | undefined = (data?.bids as [number[]])[0]?.[0];
@@ -79,9 +80,8 @@ export const Orderbook = ({
   return (
     <section
       ref={sectionRef}
-      className={`w-full md:max-h-full ${
-        isMobileOpenTrade ? "h-auto max-h-full" : "h-[450px] max-h-[450px]"
-      } md:h-full  overflow-y-hidden md:min-w-[250px] `}
+      className={`w-full md:max-h-full ${isMobileOpenTrade ? "h-auto max-h-full" : "h-[450px] max-h-[450px]"
+        } md:h-full  overflow-y-hidden md:min-w-[250px] `}
     >
       {isMobileOpenTrade || isMobile ? null : (
         <>
@@ -101,9 +101,8 @@ export const Orderbook = ({
           </div>
           <div className="bg-terciary h-[1px] w-full relative">
             <div
-              className={`h-[1px] w-1/2 bottom-0 transition-all duration-200 ease-in-out bg-font-80 absolute ${
-                !activeSection ? "left-0" : "left-1/2"
-              }`}
+              className={`h-[1px] w-1/2 bottom-0 transition-all duration-200 ease-in-out bg-font-80 absolute ${!activeSection ? "left-0" : "left-1/2"
+                }`}
             />
           </div>
         </>
@@ -130,9 +129,8 @@ export const Orderbook = ({
                   onClick={() => {
                     if (onDepthChange) onDepthChange(entry);
                   }}
-                  className={`h-[22px] ${
-                    depth === entry ? "text-base_color font-bold" : "text-white"
-                  } w-fit px-1 text-xs`}
+                  className={`h-[22px] ${depth === entry ? "text-base_color font-bold" : "text-white"
+                    } w-fit px-1 text-xs`}
                 >
                   {entry}
                 </button>
@@ -143,12 +141,11 @@ export const Orderbook = ({
       )}
       {(activeSection === OrderbookSection.ORDERBOOK &&
         (mobileActiveSection === "Orderbook" || !mobileActiveSection)) ||
-      isMobileOpenTrade ? (
+        isMobileOpenTrade ? (
         <div
           // max-h-[670px]  overflow-y-scroll
-          className={`relative h-full md:h-calc-full-button ${
-            isMobileOpenTrade ? "min-w-[140px] w-full" : "w-auto"
-          }  sm:w-auto`}
+          className={`relative h-full md:h-calc-full-button ${isMobileOpenTrade ? "min-w-[140px] w-full" : "w-auto"
+            }  sm:w-auto`}
         >
           {!data?.asks?.length && !data?.bids?.length ? (
             <div className="w-full h-full flex items-center justify-center">
@@ -164,7 +161,7 @@ export const Orderbook = ({
                   )}
                   <th className="pr-2.5 text-end font-normal"></th>
                   {isMobileOpenTrade ? null : (
-                    <th className="pr-2.5 text-end font-normal">Total $</th>
+                    <th className="pr-2.5 text-end font-normal">   Total {formatSymbol(asset?.symbol, true)}</th>
                   )}
                 </tr>
               </thead>

--- a/src/feature/perp/layouts/orderbook/index.tsx
+++ b/src/feature/perp/layouts/orderbook/index.tsx
@@ -159,9 +159,9 @@ export const Orderbook = ({
                   {isMobileOpenTrade ? null : (
                     <th className="text-end font-normal">Size</th>
                   )}
-                  <th className="pr-2.5 text-end font-normal"></th>
+                  <th className="pr-2.5 text-end font-normal">Total {formatSymbol(asset?.symbol, true)}</th>
                   {isMobileOpenTrade ? null : (
-                    <th className="pr-2.5 text-end font-normal">   Total {formatSymbol(asset?.symbol, true)}</th>
+                    <th className="pr-2.5 text-end font-normal">   Total $</th>
                   )}
                 </tr>
               </thead>


### PR DESCRIPTION
Related issues: #37 

Changes made:
- Added the missing title "Total {symbol}" to the last column of the order book table
- Used `formatSymbol` function to display only the base currency symbol

 Reason for change:
This change improves the clarity of the orderbook table by properly labeling all columns, making it easier for users to understand the data presented.



