### PR TITLE
Fix: Orderbook background on mobile devices

### DIFF
--- a/src/feature/perp/layouts/orderbook/index.tsx
+++ b/src/feature/perp/layouts/orderbook/index.tsx
@@ -235,7 +235,7 @@ export const Orderbook = ({
                       })}
 
                       <td
-                        className="absolute left-0 h-[90%] max-h-[30px] bg-red-opacity-10 z-0 transition-all duration-150 ease-linear"
+                        className="absolute left-0 h-[90%] max-h-[20px] bg-red-opacity-10 z-0 transition-all duration-150 ease-linear"
                         style={{ width: `${asksWidth[i]}%` }}
                       />
                     </tr>
@@ -298,7 +298,7 @@ export const Orderbook = ({
                       })}
 
                       <td
-                        className="absolute left-0 h-[90%] bg-green-opacity-10 z-0 transition-all duration-150 ease-linear"
+                        className="absolute left-0 h-[90%] max-h-[20px] bg-green-opacity-10 z-0 transition-all duration-150 ease-linear"
                         style={{ width: `${bidsWidth[i]}%` }}
                       />
                     </tr>


### PR DESCRIPTION
- [ ] Related issues: https://github.com/Veenoway/VeenoX/issues/39

![image](https://github.com/user-attachments/assets/ebb08b31-19b1-4acc-a5b7-08a9bd7eea3a)

- [ ] Changed made
  - Reduced the max-height of background bar from 30px to 20px
- [ ] Reason for change:
  - This change improves the background height should fit with the height of the lines like you can see on desktop
As result 
![image](https://github.com/user-attachments/assets/b84a9294-44d2-41a7-b716-1f9e2e24e579)



 
 
